### PR TITLE
change to avoid gravity redefined error

### DIFF
--- a/pickerview/src/main/res/values/attrs.xml
+++ b/pickerview/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="wheelview">
-        <attr name="gravity">
+        <attr name="wheel_gravity">
             <enum name="center" value="17"/>
             <enum name="left" value="3"/>
             <enum name="right" value="5"/>


### PR DESCRIPTION
导入包和gravity会有其它包的gravity attribute冲突，建议改名。